### PR TITLE
unformat() should use the default decimal separator

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -169,7 +169,7 @@
 	 * alias: accounting.`parse(string)`
 	 *
 	 * Decimal must be included in the regular expression to match floats (defaults to
-	 * accounting.settings.currency.decimal), so if the number uses a non-standard decimal 
+	 * accounting.settings.number.decimal), so if the number uses a non-standard decimal 
 	 * separator, provide it as the second argument.
 	 *
 	 * Also matches bracketed negatives (eg. "$ (1.99)" => -1.99)
@@ -190,8 +190,8 @@
 		// Return the value as-is if it's already a number:
 		if (typeof value === "number") return value;
 
-		// Default decimal point is "." but could be set to eg. "," in opts:
-		decimal = decimal || this.settings.currency.decimal;
+		// Default decimal point comes from settings, but could be set to eg. "," in opts:
+		decimal = decimal || this.settings.number.decimal;
 
 		 // Build regex to strip out everything except digits, decimal point and minus sign:
 		var regex = new RegExp("[^0-9-" + decimal + "]", ["g"]),

--- a/tests/qunit/methods.js
+++ b/tests/qunit/methods.js
@@ -8,10 +8,10 @@ $(document).ready(function() {
 		equals(accounting.unformat("string"), 0, 'Returns 0 for a string with no numbers');
 		equals(accounting.unformat({joss:1}), 0, 'Returns 0 for object');
 
-		accounting.settings.currency.decimal = ',';
+		accounting.settings.number.decimal = ',';
 		equals(accounting.unformat("100,00"), 100, 'Uses decimal separator from settings');
 		equals(accounting.unformat("¤1.000,00"), 1000, 'Uses decimal separator from settings');
-		accounting.settings.currency.decimal = '.';
+		accounting.settings.number.decimal = '.';
 	});
 
 	test("accounting.toFixed()", function() {


### PR DESCRIPTION
I think it is generally better to default to the decimal separator provided in the settings object instead of '.' for the unformat function.

This saves from calling accounting.unformat(v, accounting.settings.currency.decimal) a lot.
