### PR TITLE
Fixed isObject implementation for IE7 and IE8

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -69,7 +69,7 @@
 	 * Tests whether supplied parameter is a true object
 	 */
 	function isObject(obj) {
-		return toString.call(obj) === '[object Object]';
+		return obj && toString.call(obj) === '[object Object]';
 	}
 
 	/**


### PR DESCRIPTION
toString.call(undefined) or toString.call(null) will return "[object
Object] in IE7 and 8.
