### PR TITLE
Fix reference to settings

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -191,7 +191,7 @@
 		if (typeof value === "number") return value;
 
 		// Default decimal point comes from settings, but could be set to eg. "," in opts:
-		decimal = decimal || this.settings.number.decimal;
+		decimal = decimal || lib.settings.number.decimal;
 
 		 // Build regex to strip out everything except digits, decimal point and minus sign:
 		var regex = new RegExp("[^0-9-" + decimal + "]", ["g"]),


### PR DESCRIPTION
There was an error accessing settings in unformat. It was referring to `this` rather than `lib`.
