### PR TITLE
Avoid || ing with 0 to avoid triggering #63

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -1,5 +1,5 @@
 /*!
- * accounting.js v0.3.2
+ * accounting.js v0.3.3
  * Copyright 2011, Joss Crowcroft
  *
  * Freely distributable under the MIT license.
@@ -254,7 +254,7 @@
 
 			// Do some calc:
 			negative = number < 0 ? "-" : "",
-			base = parseInt(toFixed(Math.abs(number || 0), usePrecision), 10) + "",
+			base = parseInt(toFixed(Math.abs(number), usePrecision), 10) + "",
 			mod = base.length > 3 ? base.length % 3 : 0;
 
 		// Format the number:

--- a/package.json
+++ b/package.json
@@ -8,5 +8,5 @@
 	"dependencies" : {},
 	"repository" : {"type": "git", "url": "git://github.com/josscrowcroft/accounting.js.git"},
 	"main" : "accounting.js",
-	"version" : "0.3.2"
+	"version" : "0.3.3"
 }


### PR DESCRIPTION
We don't need to || with 0 again, especially since we've already done that in unformat.

Avoiding doing so, prevents #63 from happening.
