### PR TITLE
Support negative zero (-0) when formatting money

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -184,11 +184,11 @@
 			});
 		}
 
-		// Fails silently (need decent errors):
-		value = value || 0;
-
 		// Return the value as-is if it's already a number:
 		if (typeof value === "number") return value;
+
+		// Fails silently (need decent errors):
+		value = value || 0;
 
 		// Default decimal point comes from settings, but could be set to eg. "," in opts:
 		decimal = decimal || lib.settings.number.decimal;
@@ -264,6 +264,13 @@
 
 
 	/**
+	* Check if a number is negative, even if it is negative zero (-0)
+	*/
+	var isNegative = function(number) {
+		return (number < 0) || (number === 0 && (1/number) === -Infinity);
+	};
+
+	/**
 	 * Format a number into currency
 	 *
 	 * Usage: accounting.formatMoney(number, symbol, precision, thousandsSep, decimalSep, format)
@@ -301,7 +308,9 @@
 			formats = checkCurrencyFormat(opts.format),
 
 			// Choose which format to use for this value:
-			useFormat = number > 0 ? formats.pos : number < 0 ? formats.neg : formats.zero;
+			useFormat = !isNegative(number) ?
+					formats.pos :
+					isNegative(number) ? formats.neg : formats.zero;
 
 		// Return with currency symbol added:
 		return useFormat.replace('%s', opts.symbol).replace('%v', formatNumber(Math.abs(number), checkPrecision(opts.precision), opts.thousand, opts.decimal));

--- a/tests/jasmine/core/formatMoneySpec.js
+++ b/tests/jasmine/core/formatMoneySpec.js
@@ -13,7 +13,7 @@ describe('formatMoney()', function(){
         expect( accounting.formatMoney(-123) ).toBe( '$-123.00' );
         expect( accounting.formatMoney(-123.45) ).toBe( '$-123.45' );
         expect( accounting.formatMoney(-12345.67) ).toBe( '$-12,345.67' );
-    
+        expect( accounting.formatMoney(-0) ).toBe( '$-0.00' );
     });
 
     it('should allow precision to be `0` and not override with default `2`', function(){


### PR DESCRIPTION
- - -

The first problem was defaulting to zero (0) if the value was falsy in
the unformat function:

```
number = value || 0;
```

If the number was `-0` it was set to `0`.

This default value for number was moved to after the check of being a
number or not to prevent this from happening.

- - -

The second issue is determining negative numbers in JavaScript:

```
-0 < 0
false
```

So a new function `isNegative` was added to work with negative zeros as
well.

- - -

Finally, a new test case was added that demonstrates that the new
behavior works as intended.