### PR TITLE
unformat now correctly parses floating point numbers

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -169,7 +169,7 @@
 	 * Alias: `accounting.parse(string)`
 	 *
 	 * Decimal must be included in the regular expression to match floats (defaults to
-	 * accounting.settings.number.decimal), so if the number uses a non-standard decimal 
+	 * accounting.settings.number.decimal), so if the number uses a non-standard decimal
 	 * separator, provide it as the second argument.
 	 *
 	 * Also matches bracketed negatives (eg. "$ (1.99)" => -1.99)
@@ -194,10 +194,10 @@
 		decimal = decimal || lib.settings.number.decimal;
 
 		 // Build regex to strip out everything except digits, decimal point and minus sign:
-		var regex = new RegExp("[^0-9-" + decimal + "]", ["g"]),
+		var regex = new RegExp("[^0-9-" + decimal + "Ee]", ["g"]),
 			unformatted = parseFloat(
 				("" + value)
-				.replace(/\((.*)\)/, "-$1") // replace bracketed values with negatives
+				.replace(/\((.+)\)/, "-$1") // replace bracketed values with negatives
 				.replace(regex, '')         // strip out any cruft
 				.replace(decimal, '.')      // make sure decimal point is standard
 			);

--- a/tests/jasmine/core/unformatSpec.js
+++ b/tests/jasmine/core/unformatSpec.js
@@ -5,6 +5,7 @@ describe('unformat()', function(){
         expect( accounting.unformat('$ 123,456.78') ).toBe( 123456.78 );
         expect( accounting.unformat('&*()$ 123,456') ).toBe( 123456 );
         expect( accounting.unformat(';$@#$%^&123,456.78') ).toBe( 123456.78 );
+        expect( accounting.unformat(';$@#$%^&123,456.78E-19') ).toBe( 123456.78E-19 );
     });
 
     it('should work with negative numbers', function(){
@@ -12,20 +13,24 @@ describe('unformat()', function(){
         expect( accounting.unformat('$ -123,456.78') ).toBe( -123456.78 );
         expect( accounting.unformat('&*()$ -123,456') ).toBe( -123456 );
         expect( accounting.unformat(';$@#$%^&-123,456.78') ).toBe( -123456.78 );
+        expect( accounting.unformat(';$@#$%^&-123,456.78E-17') ).toBe( -123456.78E-17 );
     });
-    
-    it('should accept different decimal separators', function(){    
+
+    it('should accept different decimal separators', function(){
         expect( accounting.unformat('$ 123,456', ',') ).toBe( 123.456 );
         expect( accounting.unformat('$ 123456|78', '|') ).toBe( 123456.78 );
         expect( accounting.unformat('&*()$ 123>456', '>') ).toBe( 123.456 );
         expect( accounting.unformat(';$@#$%^&123,456\'78', '\'') ).toBe( 123456.78 );
+        expect( accounting.unformat(';$@#$%^&123,456\'78E-17', '\'') ).toBe( 123456.78E-17 );
     });
 
     it('should accept an array', function(){
-        var vals = accounting.unformat(['$ 123', '$567.89', 'R$12,345,678.901']);
+        var vals = accounting.unformat(['$ 123', '$567.89', 'R$12,345,678.901', '3.21e-17']);
         expect( vals[0] ).toBe( 123 );
         expect( vals[1] ).toBe( 567.89 );
         expect( vals[2] ).toBe( 12345678.901 );
+        expect( vals[3] ).toBe( 3.21e-17 );
+
     });
 
 });


### PR DESCRIPTION
+ unformat no longer parses empty '()' as a negative number

floating point number: unformat dropped the exponent in the orginal regex
empty brackets: the jasmine tests never ran on my system (Chrome, german language). i assume that an empty bracket should not be treated as a negative number
