### PR TITLE
Updated to handle embedded or unmatched parens.

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -197,7 +197,7 @@
 		var regex = new RegExp("[^0-9-" + decimal + "]", ["g"]),
 			unformatted = parseFloat(
 				("" + value)
-				.replace(/\((.*)\)/, "-$1") // replace bracketed values with negatives
+				.replace(/\((.+)\)/, "-$1") // replace bracketed values with negatives
 				.replace(regex, '')         // strip out any cruft
 				.replace(decimal, '.')      // make sure decimal point is standard
 			);


### PR DESCRIPTION
Right now, any parens in the input value will be converted into a negative value. This update excludes embedded or unmatched parens from this match.
