### PR TITLE
updating formatColumn to determine if first argument is a string value.

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -321,7 +321,7 @@
 	 * browsers from collapsing the whitespace in the output strings.
 	 */
 	lib.formatColumn = function(list, symbol, precision, thousand, decimal, format) {
-		if (!list) return [];
+		if (!list || isString(list)) return [];
 
 		// Build options object from second param (if object) or all params, extending defaults:
 		var opts = defaults(


### PR DESCRIPTION
@josscrowcroft
Great job on accounting.js. It's been a pleasure reading through the code. Please let me know if I can send some money to buy you a cup of coffee or beer!

As for the pull request: When a string value is passed as the first argument, every character is returned as a value in the array which can cause unwanted results.
```
accounting.formatColumn('1,234.50')
[$1.00,$0.00,$2.00,$3.00,$4.00,$0.00,$5.00,$0.00]
```
According to your comments in the code and the qunit tests, the first argument should only be an array of numbers.

I propose adding a check to detect if the first argument is a string and, if so, return an empty array. This matches scenarios like if a number, function, or object is passed as the first argument. (all return an empty array)