### PR TITLE
update regExp literal to fix failing accounting.unformat() jasmine tests.

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -197,7 +197,7 @@
 		var regex = new RegExp("[^0-9-" + decimal + "]", ["g"]),
 			unformatted = parseFloat(
 				("" + value)
-				.replace(/\((.*)\)/, "-$1") // replace bracketed values with negatives
+				.replace(/\((?=\d+)(.*)\)/, "-$1") // replace bracketed values with negatives
 				.replace(regex, '')         // strip out any cruft
 				.replace(decimal, '.')      // make sure decimal point is standard
 			);

--- a/tests/jasmine/core/unformatSpec.js
+++ b/tests/jasmine/core/unformatSpec.js
@@ -11,6 +11,7 @@ describe('unformat()', function(){
         expect( accounting.unformat('$ -123,456') ).toBe( -123456 );
         expect( accounting.unformat('$ -123,456.78') ).toBe( -123456.78 );
         expect( accounting.unformat('&*()$ -123,456') ).toBe( -123456 );
+        expect( accounting.unformat('&*()$(123,456)A$@P') ).toBe( -123456 );
         expect( accounting.unformat(';$@#$%^&-123,456.78') ).toBe( -123456.78 );
     });
     


### PR DESCRIPTION
@wjcrowcroft Hope all's well!

I'm submitting a pull request designed to fix all of the failing jasmine tests for unformatSpect.js.

I noticed a pattern in the 3 unformatSpec failures where the regular expression literal (within the replace method) was not considering the case when parentheses are simply passed as a special character. In this case (ie. accounting.unformat('&*()$ 123,456')), the expected value is a positive number but unformat returns a negative value.

I propose updating the regular expression literal to match only if an open parentheses is followed by a numeric character, then strip out both parentheses and add the negative symbol.      
IE.
`accounting.unformat('&*()$ 123,456')
 // returns 123456
`
`accounting.unformat('&*()$ (123,456)')
// returns -123456
`

The 3 failing tests, now pass. I've also added an extra test below to confirm the regExp works as designed:


`expect( accounting.unformat('&*()$(123,456)A$@P') ).toBe( -123456 );
`
 
Please reach out if there's anything that I can help further clarify in my PR. Thanks!
