### PR TITLE
Updated toFixed method to handle all floating point errors

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -215,10 +215,11 @@
 	 */
 	var toFixed = lib.toFixed = function(value, precision) {
 		precision = checkPrecision(precision, lib.settings.number.precision);
-		var power = Math.pow(10, precision);
 
-		// Multiply up by precision, round accurately, then divide and use native toFixed():
-		return (Math.round(lib.unformat(value) * power) / power).toFixed(precision);
+		var exponentialForm = Number(lib.unformat(value) + 'e' + precision);
+		var rounded = Math.round(exponentialForm);
+		var finalResult = Number(rounded + 'e-' + precision).toFixed(precision);
+		return finalResult;
 	};
 
 

--- a/tests/jasmine/core/formatNumberSpec.js
+++ b/tests/jasmine/core/formatNumberSpec.js
@@ -13,10 +13,11 @@ describe('formatNumber', function(){
 
         });
 
-        it('should fix floting point rounding error', function(){
+        it('should fix floating point rounding error', function(){
 
             expect( accounting.formatNumber(0.615, 2) ).toBe( '0.62' );
             expect( accounting.formatNumber(0.614, 2) ).toBe( '0.61' );
+            expect( accounting.formatNumber(1.005, 2) ).toBe( '1.01');
 
         });
 


### PR DESCRIPTION
@wjcrowcroft Hello! This should fix #163 #159 #111 #99 #84.

Currently `toFixed(1.005, 2)` returns `1.00` instead of expected `1.01`. This is because a floating point error in Javascript, where `1.005 * 100` is equal to `100.49999999999999`. We can get around this by using scientific notation, as `1.005e2` evaluates correctly to `100.5`. After it is rounded to `101`, it is then brought back into it's original decimal value with the same method, i.e. `101e-2`, that evaluates to `1.01`.

Also added another test for this issue.

Thanks to @gordonmzhu for the idea and logic behind this pull request.