### PR TITLE
Update toFixed to round negative values away from zero and handle exponential notation

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -216,12 +216,20 @@
 	var toFixed = lib.toFixed = function(value, precision) {
 		precision = checkPrecision(precision, lib.settings.number.precision);
 		value = unformat(value);
+
+		// Save sign so that we can round the absolute value later
 		var negative = value < 0 ? '-' : '';
-		
-		var exponentialForm = Number(value + 'e' + precision);
-		var rounded = Math.round(Math.abs(exponentialForm));
-		var finalResult = Number(negative + rounded + 'e-' + precision).toFixed(precision);
-		return finalResult;
+
+		// Convert value to exponential and split it into an array
+		var exponentialArray = value.toExponential().split('e');
+
+		// Add precision to exponent, and put it back together as an exponential value
+		// and round the absolute value (so that negative values round away from zero)
+		var rounded = Math.round(Math.abs(exponentialArray[0] + 'e' + (Number(exponentialArray[1]) + precision)));
+
+		// Divide, add sign, convert to number, and return with native toFixed()
+		var finalResult = Number(negative + rounded / Math.pow(10, precision));
+		return finalResult.toFixed(precision);
 	};
 
 

--- a/accounting.js
+++ b/accounting.js
@@ -215,10 +215,12 @@
 	 */
 	var toFixed = lib.toFixed = function(value, precision) {
 		precision = checkPrecision(precision, lib.settings.number.precision);
-
-		var exponentialForm = Number(lib.unformat(value) + 'e' + precision);
-		var rounded = Math.round(exponentialForm);
-		var finalResult = Number(rounded + 'e-' + precision).toFixed(precision);
+		value = unformat(value);
+		var negative = value < 0 ? '-' : '';
+		
+		var exponentialForm = Number(value + 'e' + precision);
+		var rounded = Math.round(Math.abs(exponentialForm));
+		var finalResult = Number(negative + rounded + 'e-' + precision).toFixed(precision);
 		return finalResult;
 	};
 

--- a/tests/jasmine/core/formatNumberSpec.js
+++ b/tests/jasmine/core/formatNumberSpec.js
@@ -55,6 +55,13 @@ describe('formatNumber', function(){
 
         });
 
+        it('should round negative numbers away from zero', function() {
+
+            expect( accounting.formatNumber(-1.5, 0) ).toBe( '-2' );
+            expect( accounting.formatNumber(-1.005, 2) ).toBe( '-1.01' );
+
+        })
+
     });
 
 

--- a/tests/jasmine/core/formatNumberSpec.js
+++ b/tests/jasmine/core/formatNumberSpec.js
@@ -60,7 +60,15 @@ describe('formatNumber', function(){
             expect( accounting.formatNumber(-1.5, 0) ).toBe( '-2' );
             expect( accounting.formatNumber(-1.005, 2) ).toBe( '-1.01' );
 
-        })
+        });
+
+        it('should work for exponential notation', function() {
+
+            expect( accounting.formatNumber(2.7755575615628914e-17, 0) ).toBe( '0' );
+            expect( accounting.formatNumber(1.2345678e+4, 0) ).toBe( '12,346' );
+            expect( accounting.formatNumber(1.2345678e+4, 2) ).toBe( '12,345.68' );
+
+        });
 
     });
 


### PR DESCRIPTION
Fixes an inconsistency between `toFixed` and `formatNumber` referenced in #164. 

Updating `toFixed` so that it rounds negative values away from zero, to be in consistence with how `formatNumber` and thus `formatMoney` has been working.

Also adding some tests to `formatNumber` to clarify this current (& past) behaviour of rounding negative values away from zero.

Before: 
```javascript
console.log(accounting.toFixed(-61.005, 2)); // "-61.00"
console.log(accounting.formatNumber(-61.005, 2)); // "-61.01"
```

with this fix:
```javascript
console.log(accounting.toFixed(-61.005, 2)); // "-61.01"
console.log(accounting.formatNumber(-61.005, 2)); // "-61.01"
```