### PR TITLE
Adding license info to the bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,5 +6,6 @@
   "keywords"    : ["accounting", "number", "money", "currency", "format", "utilities", "finance", "exchange"],
   "main"        : "accounting.js",
   "name"        : "accounting",
-  "version"     : "0.4.2"
+  "version"     : "0.4.2",
+  "license"     : "MIT"
 }


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the bower.json tools like VersionEye can fetch it easier.