### PR TITLE
Suggesting an inconsistency inside defaults function

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -85,7 +85,9 @@
 		for (key in defs) {
 			if (defs.hasOwnProperty(key)) {
 				// Replace values with defaults only if undefined (allow empty/zero values):
-				if (object[key] == null) object[key] = defs[key];
+				if (object[key] === undefined) { 
+					object[key] = defs[key];
+				}
 			}
 		}
 		return object;


### PR DESCRIPTION
There is an inaccuracy regarding the comment in line 87, regarding  __allowing for empty/ zero values__
```
// Replace values with defaults only if undefined (allow empty/ zero values) 
```
__Problem:__ 
Calling the defaults function, if object has a value of null, its value will be overwritten by the defs value. 
Below is an example:
```
defaults({color: null}, {color:'grey', wheels:2})  
 // returns {color: "grey", wheels: 2}
```
This is inconsistent with the comment, which should allow for empty/ zero values.
To fix it,  null can be swapped for undefined.

__Solution:__
With this fix, the expected output is returned. 
```
{color: null, wheels: 2},
```
If the authors consider to not replace this code due to reasons such that it might brake the code for existing users of accounting.js, I suggest to  at least  change the comment to be more accurate, for example:
```
// Replace values with defaults only if undefined.
```
Thanks to @gordonmzhu for the inspiration behind this pull request.