### PR TITLE
IsObject(null) returns null, not false

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -69,7 +69,7 @@
 	 * Tests whether supplied parameter is a true object
 	 */
 	function isObject(obj) {
-		return obj && toString.call(obj) === '[object Object]';
+		return !!(obj && toString.call(obj) === '[object Object]');
 	}
 
 	/**

--- a/accounting.js
+++ b/accounting.js
@@ -85,7 +85,9 @@
 		for (key in defs) {
 			if (defs.hasOwnProperty(key)) {
 				// Replace values with defaults only if undefined (allow empty/zero values):
-				if (object[key] == null) object[key] = defs[key];
+				if (object[key] === undefined) {
+					object[key] = defs[key];					
+				}
 			}
 		}
 		return object;
@@ -169,7 +171,7 @@
 	 * Alias: `accounting.parse(string)`
 	 *
 	 * Decimal must be included in the regular expression to match floats (defaults to
-	 * accounting.settings.number.decimal), so if the number uses a non-standard decimal 
+	 * accounting.settings.number.decimal), so if the number uses a non-standard decimal
 	 * separator, provide it as the second argument.
 	 *
 	 * Also matches bracketed negatives (eg. "$ (1.99)" => -1.99)

--- a/tests/jasmine/core/defaultsSpec.js
+++ b/tests/jasmine/core/defaultsSpec.js
@@ -1,0 +1,9 @@
+describe('defaults()', function(){
+
+    it('Defs paramter should not overwrite the value null of the object parameter', function() {
+
+        expect( defaults({flavour: null}, {flavor: "vanilla", sprinkles: "lots"}) ).toBe( {flavor: null, sprinkles: "lots"} );
+
+    });
+
+});

--- a/tests/jasmine/runner.html
+++ b/tests/jasmine/runner.html
@@ -11,6 +11,7 @@
         <script src="core/formatNumberSpec.js"></script>
         <script src="core/unformatSpec.js"></script>
         <script src="core/formatMoneySpec.js"></script>
+        <script src="core/defaultsSpec.js"></script>
     </head>
     <body>
         <script>


### PR DESCRIPTION
__Problem:__
The function isObject should return true or false, depending if the supplied parameter is a true object, but if we call it with null it will return null
```
isObject(null)
//returns null
```
__Solution:__
If we wrap the value inside !! we avoid this edge case, ensuring false will be returned if the parameter is null
``` 
isObject(null);
// returns false
````