### PR TITLE
Clarify unformat() usage (Issue #175), and fix bug related to using non-standard separators without changing default settings object (Issue #129).

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -238,9 +238,6 @@
 			});
 		}
 
-		// Clean up number:
-		number = unformat(number);
-
 		// Build options object from second param (if object) or all params, extending defaults:
 		var opts = defaults(
 				(isObject(precision) ? precision : {
@@ -249,10 +246,13 @@
 					decimal : decimal
 				}),
 				lib.settings.number
-			),
+			);
 
-			// Clean up precision
-			usePrecision = checkPrecision(opts.precision),
+		// Clean up number:
+		number = unformat(number, opts.decimal);
+
+		// Clean up precision
+		var usePrecision = checkPrecision(opts.precision),
 
 			// Do some calc:
 			negative = number < 0 ? "-" : "",
@@ -283,9 +283,6 @@
 			});
 		}
 
-		// Clean up number:
-		number = unformat(number);
-
 		// Build options object from second param (if object) or all params, extending defaults:
 		var opts = defaults(
 				(isObject(symbol) ? symbol : {
@@ -296,10 +293,13 @@
 					format : format
 				}),
 				lib.settings.currency
-			),
+			);
 
-			// Check format (returns object with pos, neg and zero):
-			formats = checkCurrencyFormat(opts.format),
+		// Clean up number:
+		number = unformat(number, opts.decimal);
+
+		// Check format (returns object with pos, neg and zero):
+		var formats = checkCurrencyFormat(opts.format),
 
 			// Choose which format to use for this value:
 			useFormat = number > 0 ? formats.pos : number < 0 ? formats.neg : formats.zero;

--- a/index.html
+++ b/index.html
@@ -95,8 +95,9 @@ accounting.toFixed(0.615, 2); // "0.62"</pre>
 
 		<h4><strong>unformat()</strong> - parse a value from any formatted number/currency string</h4>
 
-		<p>Takes any number and removes all currency formatting. Aliased as <code>accounting.parse()</code></p>
-		<pre class="prettyprint lang-js">accounting.unformat("&pound; 12,345,678.90 GBP"); // 12345678.9</pre>
+		<p>Takes any number and removes all currency formatting. If a non-standard decimal separator was used (eg. a comma) the separator is required as the second argument. Aliased as <code>accounting.parse()</code></p>
+		<pre class="prettyprint lang-js">accounting.unformat("&pound; 12,345,678.90 GBP"); // 12345678.9
+accounting.unformat("&euro; 1.000.000,00", ","); // 1000000</pre>
 	</section>
 
 	<section id="demo">

--- a/tests/jasmine/core/formatMoneySpec.js
+++ b/tests/jasmine/core/formatMoneySpec.js
@@ -20,4 +20,9 @@ describe('formatMoney()', function(){
         expect( accounting.formatMoney(5318008, "$", 0) ).toBe( '$5,318,008' );
     });
 
+    it('should accept number as string and work with non-standard separators', function(){
+        expect( accounting.formatMoney("123,45", "€ ", 2, ".", ",") ).toBe( "€ 123,45" );
+        expect( accounting.formatMoney("1.234,56", "R$ ", 2, ".", ",") ).toBe( "R$ 1.234,56" );
+    });
+
 });

--- a/tests/jasmine/core/formatNumberSpec.js
+++ b/tests/jasmine/core/formatNumberSpec.js
@@ -83,6 +83,8 @@ describe('formatNumber', function(){
             expect( accounting.formatNumber(98765432.12, 2, '&', '*') ).toBe( '98&765&432*12' );
             expect( accounting.formatNumber(98765432.12, 3, '"', '\'') ).toBe( '98"765"432\'120' );
             expect( accounting.formatNumber(98765432.12, 4, '[', ']') ).toBe( '98[765[432]1200' );
+            expect( accounting.formatNumber("123,45", 2, '.', ',') ).toBe( '123,45' );
+            expect( accounting.formatNumber("1.234,56", 2, '.', ',').toBe( '1.234,56' );
         });
 
         it('should use default separators if null', function(){

--- a/tests/qunit/methods.js
+++ b/tests/qunit/methods.js
@@ -10,8 +10,10 @@ $(document).ready(function() {
 
 		accounting.settings.number.decimal = ',';
 		equals(accounting.unformat("100,00"), 100, 'Uses decimal separator from settings');
-		equals(accounting.unformat("¤1.000,00"), 1000, 'Uses decimal separator from settings');
+		equals(accounting.unformat("ï¿½1.000,00"), 1000, 'Uses decimal separator from settings');
 		accounting.settings.number.decimal = '.';
+		equals(accounting.unformat("100,00", ","), 100, 'Accepts decimal separator as second argument')
+		equals(accounting.unformat("ï¿½1.000,00", ","), 1000, 'Accepts decimal separator as second argument')
 	});
 
 	test("accounting.toFixed()", function() {
@@ -45,7 +47,7 @@ $(document).ready(function() {
 	test("accounting.formatMoney()", function() {
 		equals(accounting.formatMoney(12345678), "$12,345,678.00", "Default usage with default parameters is ok");
 		equals(accounting.formatMoney(4999.99, "$ ", 2, ".", ","), "$ 4.999,99", 'custom formatting via straight params works ok');
-		equals(accounting.formatMoney(-500000, "£ ", 0), "£ -500,000", 'negative values, custom params, works ok');
+		equals(accounting.formatMoney(-500000, "ï¿½ ", 0), "ï¿½ -500,000", 'negative values, custom params, works ok');
 		equals(accounting.formatMoney(5318008, { symbol: "GBP",  format: "%v %s" }), "5,318,008.00 GBP", "`format` parameter is observed in string output");
 		equals(accounting.formatMoney(1000, { format: "test %v 123 %s test" }), "test 1,000.00 123 $ test", "`format` parameter is observed in string output, despite being rather strange");
 		

--- a/tests/qunit/methods.js
+++ b/tests/qunit/methods.js
@@ -32,6 +32,11 @@ $(document).ready(function() {
 			decimal : "--"
 		}), "5__318__008--000", 'Correctly handles custom precision and separators passed in via second param options object');
 
+		// works with number as string and non-standard separators (eg. { thousand: ".", decimal: "," }):
+		equal(accounting.formatNumber("123,45", 2, ".", ","), "123,45", 'Accepts number as string and handles non-standard separators as individual arguments')
+		equal(accounting.formatNumber("1.234,56", 2, ".", ","), "1.234,56", 'Accepts number as string and handles non-standard separators as individual arguments')
+		equal(accounting.formatNumber("123,45", { precision: 2, thousand: ".", decimal: "," }), "123,45", 'Accepts number as string and handles non-standard separators passed as options object')
+		equal(accounting.formatNumber("1.234,56", { precision: 2, thousand: ".", decimal: "," }), "1.234,56", 'Accepts number as string and handles non-standard separators passed as options object')
 		
 		// check rounding:
 		equals(accounting.formatNumber(0.615, 2), "0.62", 'Rounds 0.615 up to "0.62" with precision of 2');
@@ -64,6 +69,23 @@ $(document).ready(function() {
 		accounting.settings.currency.format = "%s%v";
 		accounting.formatMoney(0, {format:""});
 		equals(typeof accounting.settings.currency.format, "object", "`settings.currency.format` default string value should be reformatted to an object, the first time it is used");
+
+		// works with number as string and non-standard separators (eg. { thousand: ".", decimal: "," }):
+		equal(accounting.formatMoney("123,45", "€ ", 2, ".", ","), "€ 123,45", 'Accepts number as string and handles non-standard separators as individual arguments')
+		equal(accounting.formatMoney("1.234,56", "R$ ", 2, ".", ","), "R$ 1.234,56", 'Accepts number as string and handles non-standard separators as individual arguments')
+		equal(accounting.formatMoney("123,45", { 
+			symbol: "€ ", 
+			precision: 2, 
+			thousand: ".", 
+			decimal: "," 
+		}), "€ 123,45", 'Accepts number as string and handles non-standard separators passed as options object')
+		equal(accounting.formatMoney("1.234,56", {
+			symbol: "R$ ", 
+			precision: 2, 
+			thousand: ".", 
+			decimal: "," 
+		}), "R$ 1.234,56", 'Accepts number as string and handles non-standard separators passed as options object')
+
 	});
 
 


### PR DESCRIPTION
**Edited (26 November 2017)**: There are additional issues related to passing number as strings to formatMoney and formatNumber, so I have closed the pull request for now.

**Important:** Changes to accounting.js are not reflected in the minified version.

**Issues Addressed**

**#175** - To call unformat() on a number that uses a decimal separator other than "." (eg. a comma), user must pass in the decimal separator as the second argument to unformat(). 

Example: `accounting.unformat("100,00", ",") // 100`

This is not a bug. However, the current docs do not provide sufficient examples for the unformat method. I have updated the description of unformat() in the "Library Methods" section of the documentation with example code, as well as added QUnit tests to better demonstrate this usage.

**#129** - Some users who handle currencies which use "." as thousand separators and "," as decimal separators may prefer to pass numbers as strings into formatMoney() and formatNumber() because JavaScript will not appropriately recognize a float such as `1.234.567,89`.

If the default settings object is altered prior to using formatMoney() or formatNumber(), this works just fine:

```
accounting.settings.currency = {
  symbol: "R$",
  decimal: ",",
  thousand: ".",
  format: "%s %v"
};

accounting.settings.number = {
  precision: 2,
  decimal: ",",
  thousand: "."
};

accounting.formatMoney("123,45");    // "R$ 123,45"
accounting.formatMoney("1.234,56");  // "R$ 1.234,56"

accounting.formatNumber("123,45");   // "123,45"
accounting.formatNumber("1.234,56"); // "1.234,56"
```

However, should a user prefer not to alter the settings object (and rather pass an options object directly), this issue arises:

```
accounting.formatMoney("123,45", { 
  symbol: "R$",
  thousand: ".",
  decimal: ",",
  format: "%s %v"
}); // "R$ 12.345,00" (expected: "R$ 123,45")

accounting.formatMoney("1.234,56", {
  symbol: "R$",
  thousand: ".",
  decimal: ",",
  format: "%s %v" 
}); // "R$ 1,23" (expected: "R$ 1.234,56")
```

The same issue arises in formatNumber():

```
accounting.formatNumber("123,45", {
  precision: 2,
  thousand: ".",
  decimal: ","
}); // "12.345,00" (expected: "123,45")

accounting.formatNumber("1.234,56", {
  precision: 2,
  thousand: ".",
  decimal: ","
}); // "1,23" (expected: "1.234,56")
```

These issues occur even if options are passed individually, rather than as an object.

When exploring this issue, I noticed a rather simple change would fix it:

- unformat() takes two arguments: value, and decimal.
- Nowhere in the API methods is unformat used in this way. In both formatMoney() and formatNumber(), unformat() is called without a decimal argument even if it was passed explicitly by the user. (I suspect this was an oversight.)
- By first building the options object and _then_ cleaning the number using unformat, passing in both number and decimal separator, ie. `number = unformat(number, opts.decimal);`, this ensures the unformat method will respect the decimal separator.

Rather than adding a specific check for the usage of the Brazilian currency symbol ("R$") as proposed by PR #183, this subtle change will handle all cases where number is passed as string and non-default separators are used.

With the changes:

```
accounting.formatMoney("123,45", { 
  symbol: "R$",
  thousand: ".",
  decimal: ",",
  format: "%s %v"
}); // "R$ 123,45"

accounting.formatMoney("1.234,56", {
  symbol: "R$",
  thousand: ".",
  decimal: ",",
  format: "%s %v" 
}); // "R$ 1.234,56"

accounting.formatNumber("123,45", {
  precision: 2,
  thousand: ".",
  decimal: ","
}); // "123,45"

accounting.formatNumber("1.234,56", {
  precision: 2,
  thousand: ".",
  decimal: ","
}); // "1.234,56"
```

I have also added additional QUnit and Jasmine tests to demonstrate this minor change works.

**Final Considerations**
- As mentioned above, accounting.js needs to be minified again.
- Adding formatMoney and formatNumber tests for numbers passed as strings may be helpful.
- Jasmine coverage (especially for formatMoney) is generally poor.