### PR TITLE
fix: handle unformat symbols containing decimal separators

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -176,11 +176,11 @@
 	 *
 	 * Doesn't throw any errors (`NaN`s become 0) but this may change in future
 	 */
-	var unformat = lib.unformat = lib.parse = function(value, decimal) {
+	var unformat = lib.unformat = lib.parse = function(value, decimal, symbol) {
 		// Recursively unformat arrays:
 		if (isArray(value)) {
 			return map(value, function(val) {
-				return unformat(val, decimal);
+				return unformat(val, decimal, symbol);
 			});
 		}
 
@@ -192,12 +192,14 @@
 
 		// Default decimal point comes from settings, but could be set to eg. "," in opts:
 		decimal = decimal || lib.settings.number.decimal;
+		symbol = symbol || lib.settings.currency.symbol;
 
 		 // Build regex to strip out everything except digits, decimal point and minus sign:
 		var regex = new RegExp("[^0-9-" + decimal + "]", ["g"]),
 			unformatted = parseFloat(
 				("" + value)
 				.replace(/\((?=\d+)(.*)\)/, "-$1") // replace bracketed values with negatives
+				.split(symbol).join("")   // remove currency symbols before stripping other chars
 				.replace(regex, '')         // strip out any cruft
 				.replace(decimal, '.')      // make sure decimal point is standard
 			);

--- a/tests/jasmine/core/unformatSpec.js
+++ b/tests/jasmine/core/unformatSpec.js
@@ -22,6 +22,11 @@ describe('unformat()', function(){
         expect( accounting.unformat(';$@#$%^&123,456\'78', '\'') ).toBe( 123456.78 );
     });
 
+    it('should accept a currency symbol with the decimal separator', function(){
+        expect( accounting.unformat('kr. 123.45', '.', 'kr.') ).toBe( 123.45 );
+        expect( accounting.unformat(['kr. 123.45', 'kr. 67.89'], '.', 'kr.')[1] ).toBe( 67.89 );
+    });
+
     it('should accept an array', function(){
         var vals = accounting.unformat(['$ 123', '$567.89', 'R$12,345,678.901']);
         expect( vals[0] ).toBe( 123 );


### PR DESCRIPTION
## Summary
- add an optional `symbol` argument to `unformat()` so callers can strip currency symbols before decimal parsing
- fix the `kr.` case described in #240 where the symbol contains the decimal separator
- add a regression spec covering both string and array inputs

## Validation
- `node -e "const accounting=require('./accounting'); function assert(cond,msg){ if(!cond){ console.error(msg); process.exit(1);} } assert(accounting.unformat('kr. 123.45', '.', 'kr.')===123.45,'regression failed'); const vals=accounting.unformat(['kr. 123.45','kr. 67.89'],'.','kr.'); assert(vals[0]===123.45 && vals[1]===67.89,'array regression failed'); assert(accounting.unformat('$ 123,456.78')===123456.78,'baseline failed'); console.log('ok');"`