### PR TITLE
fix: handle tiny scientific-notation values in formatNumber

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -216,9 +216,11 @@
 	var toFixed = lib.toFixed = function(value, precision) {
 		precision = checkPrecision(precision, lib.settings.number.precision);
 
-		var exponentialForm = Number(lib.unformat(value) + 'e' + precision);
-		var rounded = Math.round(exponentialForm);
-		var finalResult = Number(rounded + 'e-' + precision).toFixed(precision);
+		var shiftedExponentials = String(lib.unformat(value)).split('e');
+		var shiftedNumber = Number(shiftedExponentials[0] + 'e' + ((shiftedExponentials[1] ? Number(shiftedExponentials[1]) : 0) + precision));
+		var rounded = Math.round(shiftedNumber);
+		var roundedExponentials = String(rounded).split('e');
+		var finalResult = Number(roundedExponentials[0] + 'e' + ((roundedExponentials[1] ? Number(roundedExponentials[1]) : 0) - precision)).toFixed(precision);
 		return finalResult;
 	};
 

--- a/tests/jasmine/core/formatNumberSpec.js
+++ b/tests/jasmine/core/formatNumberSpec.js
@@ -21,6 +21,14 @@ describe('formatNumber', function(){
 
         });
 
+        it('should format tiny numbers without returning NaN', function(){
+
+            expect( accounting.formatNumber(1e-7) ).toBe( '0' );
+            expect( accounting.formatNumber(0.0000001) ).toBe( '0' );
+            expect( accounting.formatNumber(1e-7, 8) ).toBe( '0.00000010' );
+
+        });
+
         it('should work for large numbers', function(){
             
             expect( accounting.formatNumber(123456.54321, 0) ).toBe( '123,457' );


### PR DESCRIPTION
## Summary
- make `toFixed()` handle values that are already represented in scientific notation
- preserve existing rounding behavior for normal decimal inputs
- add a regression spec for very small numbers that previously formatted as `NaN`

## Validation
- `node -e "const assert=require('assert'); const accounting=require('./accounting'); assert.strictEqual(accounting.formatNumber(1e-7), '0'); assert.strictEqual(accounting.formatNumber(0.0000001), '0'); assert.strictEqual(accounting.formatNumber(1e-7, 8), '0.00000010'); assert.strictEqual(accounting.formatNumber(0.615, 2), '0.62'); assert.strictEqual(accounting.formatNumber(123456.54321, 2), '123,456.54'); console.log('validation ok');"`

Fixes #241
