### PR TITLE
fix: handle tiny values in toFixed

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -216,9 +216,11 @@
 	var toFixed = lib.toFixed = function(value, precision) {
 		precision = checkPrecision(precision, lib.settings.number.precision);
 
-		var exponentialForm = Number(lib.unformat(value) + 'e' + precision);
+		var exponentialValues = lib.unformat(value).toString().split('e');
+		var exponentialForm = Number(exponentialValues[0] + 'e' + ((exponentialValues[1] ? (+exponentialValues[1] + precision) : precision)));
 		var rounded = Math.round(exponentialForm);
-		var finalResult = Number(rounded + 'e-' + precision).toFixed(precision);
+		var roundedValues = rounded.toString().split('e');
+		var finalResult = Number(roundedValues[0] + 'e' + ((roundedValues[1] ? (+roundedValues[1] - precision) : -precision))).toFixed(precision);
 		return finalResult;
 	};
 

--- a/tests/jasmine/core/formatNumberSpec.js
+++ b/tests/jasmine/core/formatNumberSpec.js
@@ -21,6 +21,14 @@ describe('formatNumber', function(){
 
         });
 
+        it('should handle tiny numbers written in exponential notation', function(){
+
+            expect( accounting.formatNumber(1e-7, 2) ).toBe( '0.00' );
+            expect( accounting.formatNumber(1e-7, 8) ).toBe( '0.00000010' );
+            expect( accounting.formatNumber(-1e-7, 8) ).toBe( '-0.00000010' );
+
+        });
+
         it('should work for large numbers', function(){
             
             expect( accounting.formatNumber(123456.54321, 0) ).toBe( '123,457' );

--- a/tests/qunit/methods.js
+++ b/tests/qunit/methods.js
@@ -10,13 +10,15 @@ $(document).ready(function() {
 
 		accounting.settings.number.decimal = ',';
 		equals(accounting.unformat("100,00"), 100, 'Uses decimal separator from settings');
-		equals(accounting.unformat("¤1.000,00"), 1000, 'Uses decimal separator from settings');
+		equals(accounting.unformat("ï¿½1.000,00"), 1000, 'Uses decimal separator from settings');
 		accounting.settings.number.decimal = '.';
 	});
 
 	test("accounting.toFixed()", function() {
 		equals(accounting.toFixed(54321, 5), "54321.00000", 'Performs basic float zero-padding');
 		equals(accounting.toFixed(0.615, 2), "0.62", 'Rounds 0.615 to "0.62" instead of "0.61"');
+		equals(accounting.toFixed("-0.00000000000000000000003", 2), "0.00", 'Handles tiny negative values without producing NaN');
+		equals(accounting.toFixed("-0.00000000000000000000003", 23), "-0.00000000000000000000003", 'Preserves precision for tiny negative values in exponential form');
 	});
 
 	test("accounting.formatNumber()", function() {
@@ -45,7 +47,7 @@ $(document).ready(function() {
 	test("accounting.formatMoney()", function() {
 		equals(accounting.formatMoney(12345678), "$12,345,678.00", "Default usage with default parameters is ok");
 		equals(accounting.formatMoney(4999.99, "$ ", 2, ".", ","), "$ 4.999,99", 'custom formatting via straight params works ok');
-		equals(accounting.formatMoney(-500000, "£ ", 0), "£ -500,000", 'negative values, custom params, works ok');
+		equals(accounting.formatMoney(-500000, "ï¿½ ", 0), "ï¿½ -500,000", 'negative values, custom params, works ok');
 		equals(accounting.formatMoney(5318008, { symbol: "GBP",  format: "%v %s" }), "5,318,008.00 GBP", "`format` parameter is observed in string output");
 		equals(accounting.formatMoney(1000, { format: "test %v 123 %s test" }), "test 1,000.00 123 $ test", "`format` parameter is observed in string output, despite being rather strange");
 		


### PR DESCRIPTION
## Summary
- fix `toFixed` so exponential-notation inputs are shifted correctly before and after rounding
- add regression coverage for tiny exponential-form values in both Jasmine and QUnit suites
- preserve existing rounding behavior for normal decimal inputs

## Testing
- `node -e "const accounting=require('./accounting.js'); const cases=[[accounting.toFixed('-0.00000000000000000000003',2),'0.00'],[accounting.toFixed('-0.00000000000000000000003',23),'-0.00000000000000000000003'],[accounting.formatNumber(1e-7,2),'0.00'],[accounting.formatNumber(1e-7,8),'0.00000010'],[accounting.toFixed(0.615,2),'0.62'],[accounting.toFixed(574.425,2),'574.43']]; for (const [actual, expected] of cases) { if (actual !== expected) { console.error(JSON.stringify({actual, expected})); process.exit(1);} } console.log('node-assertions: ok');"`

Fixes #233
