### PR TITLE
fix: handle tiny exponential values in formatNumber

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -216,7 +216,13 @@
 	var toFixed = lib.toFixed = function(value, precision) {
 		precision = checkPrecision(precision, lib.settings.number.precision);
 
-		var exponentialForm = Number(lib.unformat(value) + 'e' + precision);
+		var number = lib.unformat(value);
+
+		if (("" + number).indexOf('e') !== -1) {
+			return Number(number).toFixed(precision);
+		}
+
+		var exponentialForm = Number(number + 'e' + precision);
 		var rounded = Math.round(exponentialForm);
 		var finalResult = Number(rounded + 'e-' + precision).toFixed(precision);
 		return finalResult;

--- a/tests/jasmine/core/formatNumberSpec.js
+++ b/tests/jasmine/core/formatNumberSpec.js
@@ -21,6 +21,14 @@ describe('formatNumber', function(){
 
         });
 
+        it('should handle very small numbers without producing NaN', function(){
+
+            expect( accounting.formatNumber(1e-7, 2) ).toBe( '0.00' );
+            expect( accounting.formatNumber(0.0000001, 6) ).toBe( '0.000000' );
+            expect( accounting.formatNumber(-3e-23, 2) ).toBe( '-0.00' );
+
+        });
+
         it('should work for large numbers', function(){
             
             expect( accounting.formatNumber(123456.54321, 0) ).toBe( '123,457' );


### PR DESCRIPTION
## Summary
- handle exponent-notation inputs in `toFixed()` by falling back to native `Number(...).toFixed()`
- fix `formatNumber()` for very small values like `1e-7` so it returns a formatted zero instead of `NaN`
- add regression coverage for tiny positive and negative values

Closes #241.

## Validation
- `node -e "const accounting=require('./accounting'); function assertEq(actual, expected, label){ if(actual!==expected){ console.error(label + ': expected ' + expected + ', got ' + actual); process.exit(1);} } assertEq(accounting.formatNumber(0.615, 2), '0.62', 'rounding regression'); assertEq(accounting.formatNumber(1.005, 2), '1.01', 'rounding regression 2'); assertEq(accounting.formatNumber(1e-7, 2), '0.00', 'tiny positive'); assertEq(accounting.formatNumber(0.0000001, 6), '0.000000', 'tiny precision'); assertEq(accounting.formatNumber(-3e-23, 2), '-0.00', 'tiny negative'); console.log('validation-ok');"`
