### PR TITLE
fix: handle exponential notation in formatNumber

### DIFF
--- a/accounting.js
+++ b/accounting.js
@@ -216,9 +216,14 @@
 	var toFixed = lib.toFixed = function(value, precision) {
 		precision = checkPrecision(precision, lib.settings.number.precision);
 
-		var exponentialForm = Number(lib.unformat(value) + 'e' + precision);
-		var rounded = Math.round(exponentialForm);
-		var finalResult = Number(rounded + 'e-' + precision).toFixed(precision);
+		var number = lib.unformat(value),
+			numberParts = number.toString().split('e'),
+			exponent = numberParts[1] ? parseInt(numberParts[1], 10) : 0,
+			shifted = Math.round(Number(numberParts[0] + 'e' + (exponent + precision))),
+			shiftedParts = shifted.toString().split('e'),
+			shiftedExponent = shiftedParts[1] ? parseInt(shiftedParts[1], 10) : 0,
+			finalResult = Number(shiftedParts[0] + 'e' + (shiftedExponent - precision)).toFixed(precision);
+
 		return finalResult;
 	};
 

--- a/tests/jasmine/core/formatNumberSpec.js
+++ b/tests/jasmine/core/formatNumberSpec.js
@@ -21,6 +21,14 @@ describe('formatNumber', function(){
 
         });
 
+        it('should handle numbers represented in exponential notation', function(){
+
+            expect( accounting.formatNumber(1e-7, 2) ).toBe( '0.00' );
+            expect( accounting.formatNumber(1e-7, 7) ).toBe( '0.0000001' );
+            expect( accounting.formatNumber(-1e-7, 7) ).toBe( '-0.0000001' );
+
+        });
+
         it('should work for large numbers', function(){
             
             expect( accounting.formatNumber(123456.54321, 0) ).toBe( '123,457' );


### PR DESCRIPTION
## Summary
- fix 	oFixed() so values already represented in exponential notation are rounded correctly
- add regression coverage for tiny positive and negative numbers in ormatNumber

## Validation
- 
ode -e "const assert=require('assert'); const a=require(process.argv[1]); assert.strictEqual(a.formatNumber(0.615,2),'0.62'); assert.strictEqual(a.formatNumber(0.614,2),'0.61'); assert.strictEqual(a.formatNumber(1.005,2),'1.01'); assert.strictEqual(a.formatNumber(1e-7,2),'0.00'); assert.strictEqual(a.formatNumber(1e-7,7),'0.0000001'); assert.strictEqual(a.formatNumber(-1e-7,7),'-0.0000001'); console.log('validation ok');" "C:\Users\Administrator\.openclaw\workspace\tmp\accounting.js\\accounting.js"

Closes #241.